### PR TITLE
[Count] use repo aggregate count

### DIFF
--- a/lib/ecto_crux.ex
+++ b/lib/ecto_crux.ex
@@ -491,11 +491,7 @@ defmodule EctoCrux do
       @spec count(query :: Ecto.Query.t(), opts :: Keyword.t()) :: integer()
       def unquote(:count)(%Ecto.Query{} = query, opts) do
         query
-        |> exclude(:preload)
-        |> exclude(:order_by)
-        |> exclude(:select)
-        |> select(count("*"))
-        |> @repo.one(crux_clean_opts(opts))
+        |> @repo.aggregate(:count, crux_clean_opts(opts))
       end
 
       @doc """


### PR DESCRIPTION
When I use `distinct` in an ecto query the `count` in Crux returns an error like the following:

> iex(5)> Performances.init_query |> distinct([p], p.show_id) |> Performances.count(prefix: "odag_producer")
> [error] A query failed for the following reason : grouping_error (column "p0.show_id" must appear in the GROUP BY clause or be used in an aggregate function).
>               Query: "SELECT DISTINCT ON (p0.\"show_id\") count('*') FROM \"odag_producer\".\"performances\" AS p0"

              
Therefore, I updated the count with the `Repo.aggregate` function instead of the manual one : https://hexdocs.pm/ecto/Ecto.Repo.html#c:aggregate/3